### PR TITLE
Fix Duplicate Toast Notifications on Login Page

### DIFF
--- a/frontend/src/hooks/useToast.ts
+++ b/frontend/src/hooks/useToast.ts
@@ -1,5 +1,5 @@
 import { useSnackbar, type VariantType } from 'notistack';
-import { useCallback } from 'react';
+import { useCallback, useMemo } from 'react';
 
 const useToast = () => {
 	const { enqueueSnackbar } = useSnackbar();
@@ -14,13 +14,13 @@ const useToast = () => {
 		});
 	}, [enqueueSnackbar]);
 
-	return {
+	return useMemo(() => ({
 		showToast,
 		success: (message: string) => showToast(message, 'success'),
 		error: (message: string) => showToast(message, 'error'),
 		info: (message: string) => showToast(message, 'info'),
 		warning: (message: string) => showToast(message, 'warning'),
-	};
+	}), [showToast]);
 };
 
 export default useToast;

--- a/frontend/src/pages/Login.tsx
+++ b/frontend/src/pages/Login.tsx
@@ -15,7 +15,7 @@ import { Visibility, VisibilityOff } from '@mui/icons-material';
 import { useNavigate } from 'react-router-dom';
 import useToast from '../hooks/useToast';
 import { useAppDispatch, useAppSelector } from '../store/hooks';
-import { loginUser } from '../store/slices/authSlice';
+import { loginUser, clearError } from '../store/slices/authSlice';
 
 const Login: React.FC = () => {
 	const dispatch = useAppDispatch();
@@ -37,8 +37,9 @@ const Login: React.FC = () => {
 	useEffect(() => {
 		if (error) {
 			toast.error(typeof error === 'string' ? error : 'Login failed');
+			dispatch(clearError());
 		}
-	}, [error, toast]);
+	}, [error, toast, dispatch]);
 
 	const handleTogglePasswordVisibility = () => {
 		setShowPassword((prev: boolean) => !prev);


### PR DESCRIPTION
Fixed duplicate toast notifications on the login page by memoizing the useToast hook and clearing the error state after it has been displayed.

Fixes #144

---
*PR created automatically by Jules for task [17530004730216963736](https://jules.google.com/task/17530004730216963736) started by @daran6255*